### PR TITLE
CI(security): Resolve zizmor auditor findings

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,8 +20,7 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Required to create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -13,6 +13,11 @@ on:
 
 permissions: {}
 
+# Serialize release promotions: only one tag-push run proceeds at a time
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   validate_tag:
     name: 'Validate Tag'
@@ -53,7 +58,7 @@ jobs:
     needs: validate_tag
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: write  # Promote (publish) the draft release
     timeout-minutes: 5
     steps:
       # Harden the runner used by this workflow

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -24,29 +24,35 @@ jobs:
   tests:
     name: 'Test local GitHub Action'
     runs-on: 'ubuntu-latest'
+    # Run this job in a dedicated environment so its execution and any
+    # environment-scoped secrets can be gated by environment protection
+    # rules (satisfies zizmor's secrets-outside-env).
+    environment: 'development'
     permissions:
       contents: read
     timeout-minutes: 10 # Increase this timeout value as needed
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Test vars/secrets are available'
         run: |
           # Test vars/secrets are available
-          if [ -n "${{ vars.NEXUS_IQ_SERVER }}" ]; then
-            echo "NEXUS_IQ_SERVER: ${{ vars.NEXUS_IQ_SERVER }}"
+          if [ -n "${VARS_NEXUS_IQ_SERVER}" ]; then
+            echo "NEXUS_IQ_SERVER: ${VARS_NEXUS_IQ_SERVER}"
           else
             echo "NEXUS_IQ_SERVER is not available"
             error='true'
           fi
-          if [ -n "${{ vars.NEXUS_IQ_USERNAME }}" ]; then
-            echo "NEXUS_IQ_USERNAME: ${{ vars.NEXUS_IQ_USERNAME }}"
+          if [ -n "${VARS_NEXUS_IQ_USERNAME}" ]; then
+            echo "NEXUS_IQ_USERNAME: ${VARS_NEXUS_IQ_USERNAME}"
           else
             echo "NEXUS_IQ_USERNAME is not available"
             error='true'
           fi
-          if [ -n "${{ secrets.NEXUS_IQ_PASSWORD }}" ]; then
+          if [ -n "${SECRET_NEXUS_IQ_PASSWORD}" ]; then
             echo "NEXUS_IQ_PASSWORD is set"
           else
             echo "NEXUS_IQ_PASSWORD is not available"
@@ -59,6 +65,10 @@ jobs:
           else
             echo "All mandatory variables/secrets are available ✅"
           fi
+        env:
+          VARS_NEXUS_IQ_SERVER: ${{ vars.NEXUS_IQ_SERVER }}
+          VARS_NEXUS_IQ_USERNAME: ${{ vars.NEXUS_IQ_USERNAME }}
+          SECRET_NEXUS_IQ_PASSWORD: ${{ secrets.NEXUS_IQ_PASSWORD }}
 
       - name: "Running local action: ${{ github.repository }}"
         uses: ./

--- a/action.yaml
+++ b/action.yaml
@@ -118,7 +118,7 @@ runs:
 
     - name: 'Setup Sonatype CLI'
       # yamllint disable-line rule:line-length
-      uses: sonatype/actions/setup-iq-cli@3bec72e6daf541cf541636e4493212c2fcf0a149 # v.1.12.0
+      uses: sonatype/actions/setup-iq-cli@3bec72e6daf541cf541636e4493212c2fcf0a149 # v1.12.0
       with:
         iq-cli-version: ${{ inputs.iq_cli_version }}
 
@@ -134,6 +134,8 @@ runs:
       # yamllint disable-line rule:line-length
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       if: inputs.no_checkout != 'true'
+      with:
+        persist-credentials: false
 
     - name: 'Debug action/environment'
       if: inputs.debug == 'true'


### PR DESCRIPTION
## Summary

Drives the [zizmor](https://docs.zizmor.sh) static analysis to **zero
findings at the `auditor` persona** — the level the central CI security
scan uses (previously this branch only cleared `pedantic`, leaving the
`auditor`-only medium findings visible on the dashboard).

## Findings addressed

| Audit | Sev | Count | Fix |
| ----- | --- | ----- | --- |
| `secrets-outside-env` | medium | 2 | Bind the test job to the shared `development` environment so the Nexus IQ secret is scoped to a gated environment rather than the repository scope. |
| `artipacked` | low | 2 | `persist-credentials: false` on the composite action and testing checkouts. |
| `ref-version-mismatch` | low | 1 | Correct the `setup-iq-cli` version comment to match the pinned SHA (`v.1.12.0` → `v1.12.0`). |
| `template-injection` | low | 5 | Hoist `vars.*` / `secrets.NEXUS_IQ_PASSWORD` expansions into `env:` vars referenced from the `run` block. |
| `concurrency-limits` | low | 1 | Workflow-level `concurrency` group on the tag-push release workflow. |
| `undocumented-permissions` | low | 2 | Trailing explanatory comments on non-baseline permission grants. |

## Validation

- `zizmor --persona=auditor .` → **No findings to report**.
- `pre-commit` (yamllint, actionlint, reuse, workflow validators) passes.