### PR TITLE
Feat: Add error handling and CLI property inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,50 @@ steps:
 
 <!-- markdownlint-disable MD013 -->
 
-| Name              | Required | Default  | Description                                          |
-| ----------------- | -------- | -------- | ---------------------------------------------------- |
-| nexus_iq_server   | True     |          | Nexus IQ Server URL                                  |
-| nexus_iq_username | True     |          | Nexus IQ USERNAME                                    |
-| nexus_iq_password | True     |          | Nexus IQ Password                                    |
-| java_distribution | False    | temurin  | JAVA SE distribution to setup/run for Nexus CLI tool |
-| java_version      | False    | 17       | Java runtime to setup/run for Nexus CLI tool         |
-| iq_cli_version    | False    | 2.4.2-01 | Specific version of Nexus CLI to setup/run           |
-| application_id    | False    |          | Organisation and project name in Nexus IQ            |
-| scan_targets      | False    | .        | Location of file(s) or folder(s) to scan             |
-| no_checkout       | False    | false    | Do not checkout local repository; used for testing   |
-| debug             | False    | false    | Enable debugging output                              |
+| Name                    | Required | Default   | Description                                              |
+| ----------------------- | -------- | --------- | -------------------------------------------------------- |
+| nexus_iq_server         | True     |           | Nexus IQ Server URL                                      |
+| nexus_iq_username       | True     |           | Nexus IQ USERNAME                                        |
+| nexus_iq_password       | True     |           | Nexus IQ Password                                        |
+| java_distribution       | False    | temurin   | JAVA SE distribution to setup/run for Nexus CLI tool     |
+| java_version            | False    | 17        | Java runtime to setup/run for Nexus CLI tool             |
+| iq_cli_version          | False    | 2.13.0-01 | Specific version of Nexus CLI to setup/run               |
+| application_id          | False    |           | Organisation and project name in Nexus IQ                |
+| scan_targets            | False    | .         | Location of file(s) or folder(s) to scan                 |
+| ignore_scanning_errors  | False    | false     | Ignore scanning errors (invalid/inaccessible files)      |
+| ignore_system_errors    | False    | false     | Ignore system errors (IO, network, server, etc.)         |
+| fail_on_policy_warnings | False    | false     | Fail the scan when policy evaluation warnings occur      |
+| advanced_properties     | False    |           | System properties for the Nexus IQ CLI (key=value pairs) |
+| no_checkout             | False    | false     | Do not checkout local repository; used for testing       |
+| debug                   | False    | false     | Enable debugging output                                  |
 
 <!-- markdownlint-enable MD013 -->
+
+### Excluding Folders from the Scan
+
+The Nexus IQ CLI has no dedicated exclusion flag; pass scanner system
+properties through `advanced_properties` instead. This matters when
+build steps populate the workspace with content that breaks or skews
+the scan (e.g. scaffolding templates containing placeholder
+`package.json` files, tool caches, or downloaded runtimes).
+
+```yaml
+steps:
+  - name: "Sonatype Lifecycle Scan"
+    uses: lfreleng-actions/sonatype-lifecycle-scan-action@main
+    with:
+      nexus_iq_password: ${{ secrets.nexus_iq_password }}
+      advanced_properties: |
+        dirExcludes=**/.*,**/CVS,**/node_modules/@schematics/**
+```
+
+`dirExcludes`/`fileExcludes` accept comma-separated Ant-style patterns
+and replace the scanner defaults (`**/.*,**/CVS`), so keep those
+defaults when adding new patterns. Do not put spaces in a property
+value: properties split on whitespace and newlines, so a space would
+break the value into separate tokens. To keep invalid files from
+failing the scan without excluding them, set
+`ignore_scanning_errors: 'true'` instead.
 
 ### Required Inputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -43,8 +43,31 @@ inputs:
   iq_cli_version:
     description: 'Specific version of Nexus CLI to setup/run'
     required: false
-    # default: '2.4.2-01'
-    default: 'latest'
+    # Note: the 'latest' alias resolves to the version embedded in the
+    # sonatype/actions release and can lag behind the current CLI
+    default: '2.13.0-01'
+    # type: string
+  ignore_scanning_errors:
+    description: 'Ignore scanning errors (invalid/inaccessible files)'
+    required: false
+    default: 'false'
+    # type: boolean
+  ignore_system_errors:
+    description: 'Ignore system errors (IO, network, server, etc.)'
+    required: false
+    default: 'false'
+    # type: boolean
+  fail_on_policy_warnings:
+    description: 'Fail the scan when policy evaluation warnings occur'
+    required: false
+    default: 'false'
+    # type: boolean
+  advanced_properties:
+    description: >-
+      System properties passed to the Nexus IQ CLI; accepts multiple
+      key=value pairs, space-separated or one per line
+    required: false
+    default: ''
     # type: string
   application_id:
     description: 'Organisation and project name in Nexus IQ'
@@ -159,4 +182,8 @@ runs:
         password: ${{ inputs.nexus_iq_password }}
         application-id: ${{ inputs.application_id }}
         scan-targets: ${{ inputs.scan_targets }}
+        ignore-scanning-errors: ${{ inputs.ignore_scanning_errors }}
+        ignore-system-errors: ${{ inputs.ignore_system_errors }}
+        fail-on-policy-warnings: ${{ inputs.fail_on_policy_warnings }}
+        advanced-properties: ${{ inputs.advanced_properties }}
         debug: ${{ inputs.debug }}


### PR DESCRIPTION
# Feat: Add error handling and CLI property inputs

## Problem

Nexus IQ CLI runs fail hard when the scanned workspace contains unparseable files. Example: ONAP `usecase-ui` CLM scans run `npm install` in a pre-scan build, which populates `node_modules/@schematics/angular/` with scaffolding templates whose `package.json` files contain EJS `<%= %>` placeholders (intentionally invalid JSON). The CLI then:

1. Logs `Failed to process package.json` scanning errors
2. Completes the policy evaluation and uploads the report successfully
3. Writes an error result file (`{"errorMessage": "Scanning errors encountered", "isScanningError": true}`) with **no `scanId`** and exits non-zero
4. The `sonatype/actions/run-iq-cli` wrapper hard-fails the step

The wrapper exposes the controls for this, but this action doesn't pass them through.

## Changes

New inputs (all defaulting to current behaviour):

| Input | Purpose |
| ----- | ------- |
| `ignore_scanning_errors` | Tolerate invalid/inaccessible files (`-E`) |
| `ignore_system_errors` | Tolerate IO/network/server errors (`-e`) |
| `fail_on_policy_warnings` | Gate on policy warnings (`-w`) |
| `advanced_properties` | Arbitrary `-D` system properties, e.g. `dirExcludes=` folder exclusions |

Also:

- Bump `sonatype/actions` pins v1.12.0 → v1.13.0 (granular exit codes)
- Pin default `iq_cli_version` to `2.13.0-01` (current release). The previous `latest` alias resolves to the CLI version embedded in the `sonatype/actions` release — currently 2.7.0-01 — which lags the actual current release
- README: document the folder-exclusion use case via `advanced_properties`

## Validation

- Both mechanisms verified against the live LF Nexus IQ server with the `onap/usecase-ui` workspace (JDK 11 build, CLI under JDK 17):
  - `--ignore-scanning-errors`: exit 0, result JSON contains `scanId` + `policyAction`
  - `-D dirExcludes=...`: exit 0, no parse errors, template components excluded (1582 → 1576 components)
- CLI `2.13.0-01` verified to run on Java 17 and support all exposed flags
- `prek run --all-files`, `zizmor --persona auditor` (zero findings), `markdown-table-fixer` — all clean

## Downstream

`lfit/releng-reusable-workflows` `reuse-sonatype-lifecycle.yaml` will expose the same inputs (draft PR pending this merge/release), unblocking the failing ONAP CLM scans without downgrading the CLI to the legacy 1.x series.